### PR TITLE
Added support for mysql rollback caused by deadlock.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,14 @@ name := "squeryl-tools"
 
 scalaVersion := "2.10.2"
 
-version := "1.0"
+version := "1.1-SNAPSHOT"
 
 organization :="com.lunatech"
 
 libraryDependencies ++= Seq(
   "org.squeryl" %% "squeryl" % "0.9.5-6",
   "postgresql" % "postgresql" % "9.1-901.jdbc4",
+  "mysql" % "mysql-connector-java" % "5.1.25",
   "org.slf4j" % "slf4j-api" % "1.7.5",
   "org.specs2" %% "specs2" % "2.2.2" % "test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "squeryl-tools"
 
 scalaVersion := "2.10.2"
 
-version := "1.1-SNAPSHOT"
+version := "1.1"
 
 organization :="com.lunatech"
 


### PR DESCRIPTION
Now can also deal with MySQL deadlock-induced rollbacks.

Another option would be to further generalize this to a java.sql.SQLException[1].
Both the MySQLTransactionRollbackException[2] and the PSQLException[3] inherit the 'getSQLState' method from there. Doing that would also remove both dependencies on specific jdbc drivers.

1: https://docs.oracle.com/javase/8/docs/api/index.html?java/sql/SQLException.html
2: http://www.docjar.com/docs/api/com/mysql/jdbc/exceptions/MySQLTransactionRollbackException.html
3: https://jdbc.postgresql.org/development/privateapi/index.html?org/postgresql/util/PSQLException.html